### PR TITLE
docs: update repo link of anatole theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - [theme-modern-starter](https://github.com/halo-sigs/theme-modern-starter) - 集成了现代前端技术栈的 Halo 2.0 的主题开发模板。
 - [theme-astro-starter](https://github.com/halo-sigs/theme-astro-starter) - 与 Astro 集成的主题模板，使用 Astro 对模板进行预编译。
 - [theme-earth](https://github.com/halo-dev/theme-earth) - Halo 2.0 的默认主题
-- [theme-anatole](https://github.com/halo-sigs/theme-anatole) - 适用于 Halo 2.0 的 Anatole 主题
+- [halo-theme-anatole](https://github.com/halo-dev/halo-theme-anatole) - 适用于 Halo 2.0 的 Anatole 主题
 
 #### 社区
 


### PR DESCRIPTION
原 https://github.com/halo-sigs/theme-anatole 已经被归档，目前 Anatole 主题的 Halo 2.0 版本重新使用原来的仓库托管。

/kind documentation

```release-note
None
```