### PR TITLE
add vscode-extension-halo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 ### 其他
 
 - [attachment-upload-cli](https://github.com/halo-sigs/attachment-upload-cli) - 支持在 Terminal 中上传文件到 Halo 并得到链接，兼容 Typora 编辑器的图片上传。
+- [vscode-extension-halo](https://github.com/halo-sigs/vscode-extension-halo) - VSCode 插件，在 VSCode 中发布 Markdown 文档到 Halo。
 
 ## Halo 1.x
 


### PR DESCRIPTION
添加 https://github.com/halo-sigs/vscode-extension-halo 项目，这是一个可以在 VSCode 发布 Markdown 文档到 Halo 的 VSCode 插件。

```release-note
None
```