### PR TITLE
add plugin typecho

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 - [plugin-douban](https://github.com/chengzhongxue/plugin-douban) - Halo 2.0 的豆瓣插件，可以为主题提供豆瓣数据及 `/douban` 页面路由。
 - [plugin-link-security-detect](https://github.com/wenjing-xin/plugins-links-security-detect) - Halo 2.0 的安全条跳转中台插件，防止恶意链接直接跳转导致本站被搜索引擎拉黑的风险。
 - [halo-lsky-pro](https://github.com/ichenhe/halo-lsky-pro) - 集成 [Lsky Pro](https://www.lsky.pro/) 兰空图床作为 Halo 2.0 的存储后端。
+- [halo-plugin-typecho](https://github.com/mashirot/halo-plugin-typecho) - 为 Halo 2.0 提供 Typecho 页面&文章 的迁移功能，需要配合Typecho侧插件使用。
 
 ### 其他
 


### PR DESCRIPTION
为 Halo 2.0 提供 Typecho 页面&文章 的迁移功能，需要配合Typecho侧插件使用。

https://github.com/mashirot/halo-plugin-typecho

请帮忙发布至应用商店

```
NONE
```