### PR TITLE
add plugin-uni-halo

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@
 - [elog](https://github.com/LetTTGACO/elog) - 开放式跨平台博客解决方案，随意组合写作平台(语雀/Notion/FlowUs/飞书)和博客平台(Hexo/Vitepress/Halo/Confluence/WordPress等)
 - [Halo Image Plugin](https://github.com/GodlessLiu/Halo-Image-Plugin) - 浏览器插件，一键上传图片到 Halo 附件。
 - [siyuan-plugin-publisher](https://github.com/terwer/siyuan-plugin-publisher) - 支持将思源笔记的文章发布到 Halo。
+- [plugin-uni-halo](https://github.com/ialley-workshop-open/plugin-uni-halo) - 为 uni-halo v2.0 小程序提供单独的配置功能。


### PR DESCRIPTION
## UniHalo 小程序配置插件

> 为免费开源的 `uni-halo v2.0` 微信小程序提供配套的配置插件， 

### 1、插件相关

* 小程序文档：https://uni-halo.925i.cn/
* 小程序仓库：https://github.com/ialley-workshop-open/uni-halo
* 插件仓库：https://github.com/ialley-workshop-open/plugin-uni-halo

### 2、插件预览

![image](https://github.com/halo-sigs/awesome-halo/assets/49033970/2c85a7ed-ad4f-4f35-860f-dda7a5b241db)

```release-note
None
```