### PR TITLE
add plugin-thyuu-embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@
 - [halo-plugin-aplayer](https://github.com/Aziteee/halo-plugin-aplayer) - 集成 [APlayer](https://aplayer.js.org/) 音乐播放器与 [MetingJS](https://github.com/metowolf/MetingJS) 到 Halo 2.0。
 - [halo-plugin-pangu]() - 自动对文章内容执行 [Pangu](https://github.com/vinta/pangu.js) 格式化，在中英文之间加入空格。
 - [halo-plugin-auto-backup](https://github.com/yuxuefenfei/halo-plugin-auto-backup) - Halo自动备份插件
+- [plugin-thyuu-embed](https://github.com/chengzhongxue/plugin-thyuu-embed) - 区块插件，支持 嵌入视频，嵌入音乐。
 
 ### 其他
 


### PR DESCRIPTION
#### 仓库地址
https://github.com/chengzhongxue/plugin-thyuu-embed

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
后续 Halo 应用市场支持开发者注册和发布应用后，我们会转移应用的所有权。
-->

```release-note
None
```
