### PR TITLE
Add plugin-dplayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@
 - [plugin-jyfac](https://github.com/PpKoK/halo-plugin-jyfac/) - 一个非侵入式的胶囊公告栏，适配大部分主题。
 - [plugin-data-statistics](https://github.com/acanyo/plugin-data-statistics) - 为 Halo2 提供强大的数据可视化统计功能，支持 Umami 流量统计、网站内部数据图表（标签、分类、文章趋势、评论排行、热门文章等），可在编辑器中灵活插入
 - [plugin-timeline](https://github.com/acanyo/plugin-timeline) - 为为 Halo2 提供时间轴组件、横向/竖向布局，可在编辑器中灵活插入。
-- [plugin-dplayer](https://github.com/chengzhongxue/plugin-dplayer) - 这是一个基于DPlayer实现的视频剧集播放器插件，支持单个视频以及多集视频剧集播放
+- [plugin-dplayer](https://github.com/chengzhongxue/plugin-dplayer) - 这是一个基于 DPlayer 实现的视频剧集播放器插件，支持单个视频以及多集视频剧集播放。
 
 ### 其他
 


### PR DESCRIPTION
#### 仓库地址

https://github.com/chengzhongxue/plugin-dplayer

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
Dplayer剧集视频播放器
```
