### PR TITLE
提交halo-theme-sky-blog-1主题

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 #### 仓库地址
 
-[](https://github.com/sky121666/halo-theme-sky-blog-1)
+[https://github.com/sky121666/halo-theme-sky-blog-1](https://github.com/sky121666/halo-theme-sky-blog-1)
 #### 应用市场
 
 - [✅] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。


### PR DESCRIPTION
#### 仓库地址
[https://github.com/sky121666/halo-theme-sky-blog-1](https://github.com/sky121666/halo-theme-sky-blog-1)

#### 应用市场

- [✅] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
None
```
