### PR TITLE
Add halo-theme-sky-blog-1 to theme list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 - [halo-theme-vapor](https://github.com/iscottt/halo-theme-vapor) - 一款简约风格的博客主题, 移植于 CaliCastle 的 [Cali.so](https://github.com/CaliCastle/cali.so)
 - [go-halo-theme](https://github.com/dengxiwang/go-halo-theme) - 一款简约的个人技术博客主题，参考 theme-earth 做了样式优化。
 - [halo-theme-fuwari](https://github.com/jiewenhuang/halo-theme-fuwari) - 一款个人博客主题，移植自 `Astro` 同名静态博客模板[Fuwari](https://github.com/saicaca/fuwari)。
-- [halo-theme-sky-blog-1](https://github.com/sky121666/halo-theme-sky-blog-1) - 一款技术博客主题,99.9%代码使用ai辅助制作.基于Vite、Tailwind CSS、DaisyUI和Alpine.js的现代化Halo主题.
+- [halo-theme-sky-blog-1](https://github.com/sky121666/halo-theme-sky-blog-1) - 一款技术博客主题，99.9% 代码使用 AI 辅助制作，基于 Vite、Tailwind CSS、DaisyUI 和 Alpine.js的现代化 Halo 主题
 
 ### 插件
 


### PR DESCRIPTION
#### 仓库地址
[https://github.com/sky121666/halo-theme-sky-blog-1](https://github.com/sky121666/halo-theme-sky-blog-1)

#### 应用市场

- [✅] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
None
```
