### PR TITLE
申请插件上架到应用商店

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 - [plugin-cdn-cache](https://github.com/SwaggyMacro/plugin-cdn-cache) - 一个用于 Halo 2.x 的 CDN 缓存自动刷新插件。当文章/页面发布、更新或评论审核通过时，自动刷新对应页面的 CDN 缓存。支持 阿里云、腾讯云、Cloudflare。
 - [plugin-excalidraw](https://github.com/acanyo/plugin-excalidraw) - 在 Halo 文章编辑器中集成 [Excalidraw](https://excalidraw.com/) 手绘风格白板，支持创建、编辑和保存绘图，可将 `.excalidraw` 文件上传到附件库备份管理。
 - [plugin-storage-toolkit](https://github.com/Tim0x0/halo-plugin-storage-toolkit) - 存储增强插件：支持图片处理、格式转换、水印添加等功能
+- [Halo-Plugin-Dicebear-Avatar](https://github.com/YunJian101/Halo-Plugin-Dicebear-Avatar) - 利用 DiceBear API 为评论区无 Gravatar 头像的用户生成十余种风格的个性化头像，兼容官方评论组件，无需额外配置网络镜像。
 ### 其他
 
 - [attachment-upload-cli](https://github.com/halo-sigs/attachment-upload-cli) - 支持在 Terminal 中上传文件到 Halo 并得到链接，兼容 Typora 编辑器的图片上传。


### PR DESCRIPTION
#### 仓库地址
https://github.com/YunJian101/Halo-Plugin-Dicebear-Avatar
#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。


```release-note
**Features**
- 支持调用 DiceBear API 生成十余种风格的评论区头像
- 自动为无 Gravatar 头像的用户生成唯一头像
- 兼容 Gravatar 协议，无需额外配置网络镜像
**Compatibility**
- Halo Version: 2.x
- 依赖组件：官方评论组件
```
