### PR TITLE
提交Passkey插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@
 - [plugin-excalidraw](https://github.com/acanyo/plugin-excalidraw) - 在 Halo 文章编辑器中集成 [Excalidraw](https://excalidraw.com/) 手绘风格白板，支持创建、编辑和保存绘图，可将 `.excalidraw` 文件上传到附件库备份管理。
 - [plugin-storage-toolkit](https://github.com/Tim0x0/halo-plugin-storage-toolkit) - 存储增强插件：支持图片处理、格式转换、水印添加等功能
 - [Halo-Plugin-Dicebear-Avatar](https://github.com/YunJian101/Halo-Plugin-Dicebear-Avatar) - 利用 DiceBear API 为评论区无 Gravatar 头像的用户生成十余种风格的个性化头像，兼容官方评论组件，无需额外配置网络镜像。
-- [plugin-auth-passkey](https://github.com/iLay1678/halo-plugin-auth-passkey) - 为 Halo 提供 Passkey (WebAuthn) 无密码认证支持
+- [auth-passkey](https://github.com/iLay1678/halo-plugin-auth-passkey) - 为 Halo 提供 Passkey (WebAuthn) 无密码认证支持
 ### 其他
 
 - [attachment-upload-cli](https://github.com/halo-sigs/attachment-upload-cli) - 支持在 Terminal 中上传文件到 Halo 并得到链接，兼容 Typora 编辑器的图片上传。


### PR DESCRIPTION
#### 仓库地址
https://github.com/iLay1678/halo-plugin-auth-passkey
#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->
Halo官网用户名`ilay`

```release-note
为 Halo 提供 Passkey (WebAuthn) 无密码认证支持
```
