### PR TITLE
add plugin-aimodel-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@
 - [plugin-typst](https://github.com/Einstein-schrodinger/halo-plugin-typst) - 为默认编辑器和文章渲染提供 Typst 支持
 - [plugin-steam](https://github.com/Tim0x0/halo-plugin-steam) - Halo Steam展示插件: 展示 Steam 用户资料、游戏库和最近游玩记录
 - [plugin-lottery](https://github.com/acanyo/plugin-lottery) - 一款简单易用的抽奖插件，支持大转盘、抽签、定时开奖等多种玩法，轻松为站点增添互动乐趣。
+- [plugin-aimodel-hub](https://github.com/acanyo/plugin-aimodel-hub) - 为 Halo 插件生态提供统一的 AI 模型调用能力。
 
 ### 其他
 


### PR DESCRIPTION
#### 仓库地址
https://github.com/acanyo/plugin-aimodel-hub
#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
为 Halo 插件提供统一的 AI 能力调用接口，支持 OpenAI、智谱、硅基流动等多个模型供应商。
```
