### PR TITLE
Add picsky/halo-theme-retypeset

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [theme-Jyf](https://github.com/PpKoK/theme-jyf) - Halo 极简纯文字博客主题
 - [theme-sky blog 2](https://github.com/sky121666/theme-sky-blog-2) - 复古终端风格主题，支持全键盘操作与 Vim 快捷键
 - [theme-Serenity-Grace](https://github.com/atangccc/Serenity-Grace) - 简约优雅的 Halo 博客主题，以樱花粉与湖水蓝为主色调，支持亮暗模式。
+- [theme-retypeset](https://github.com/picsky/halo-theme-retypeset) - 一款专注排版的博客主题，移植自 astro-theme-retypeset，适配 Halo 博客平台。以纸质书般的阅读体验，重新唤醒排版之美。
 
 ### 插件
 


### PR DESCRIPTION
#### 应用信息：
* 应用名称：重新编排
* 应用类型：主题
* 仓库地址：https://github.com/picsky/halo-theme-retypeset/
* 应用简介：一款专注排版的博客主题，移植自 [astro-theme-retypeset](https://github.com/radishzzz/astro-theme-retypeset)，适配 [Halo](https://www.halo.run/) 博客平台。以纸质书般的阅读体验，重新唤醒排版之美。

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。
* halo官网用户名：shunkang
<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->


```release-note
None
```
