### PR TITLE
Add plugin-redirects to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@
 - [plugin-aimodel-hub](https://github.com/acanyo/plugin-aimodel-hub) - 为 Halo 插件生态提供统一的 AI 模型调用能力。
 - [plugin-typst](https://github.com/sqwfly/halo-plugin-tikz) - 为默认编辑器和文章渲染提供 TikZ 支持
 - [plugin-redis-connector](https://github.com/acanyo/plugin-redis-connector) - 为其他插件提供统一的 Redis 操作能力
+- [plugin-redirects](https://github.com/Leezj9671/halo-redirects) - 管理 SEO 和页面 URL变动时的重定向能力
 
 ### 其他
 


### PR DESCRIPTION
#### 仓库地址

https://github.com/Leezj9671/halo-redirects

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
None
```
