### PR TITLE
Add plugin-openlist to the README.md plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@
 - [plugin-redirects](https://github.com/Leezj9671/halo-redirects) - 管理 SEO 和页面 URL变动时的重定向能力
 - [plugin-ui-beautify](https://github.com/pandyzhou/plugin-ui-beautify) - 为 Halo 后台 Console 和网关页面提供 6 种视觉风格切换、动态装饰效果和自定义 CSS 注入。
 - [plugin-steamview](https://github.com/sailtrack410/plugin-steamview) - 为 Halo 提供 steam 游戏的前台及编辑器展示
+- [plugin-openlist](https://github.com/pandyzhou/plugin-openlist) - 将 OpenList/AList 作为 Halo 附件存储后端，支持多实例配置和文件同步。
 
 ### 其他
 


### PR DESCRIPTION
## 应用信息

- 应用名称：OpenList 附件存储
- 应用类型：插件
- 仓库地址：https://github.com/pandyzhou/plugin-openlist
- 简介：将 OpenList/AList 作为 Halo 附件存储后端，支持多实例配置和文件同步
- 协议：MIT


Halo 官网用户名：zhouyi

#### 仓库地址

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
None
```
