### PR TITLE
添加theme-sky-blog-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 - [theme-retypeset](https://github.com/picsky/halo-theme-retypeset) - 一款专注排版的博客主题，移植自 astro-theme-retypeset，适配 Halo 博客平台。以纸质书般的阅读体验，重新唤醒排版之美。
 - [theme-daisym](https://github.com/ting1e/halo-theme-daisym) - 支持首页自由拖动的极简博客主题。
 - [Wing](https://github.com/waistu/halo-theme-Wing) - 一款简洁流畅、数据驱动的响应式主题。
+- [theme-sky-blog-3(macos)](https://github.com/sky121666/theme-sky-blog-3) - Apple-like macOS 桌面壳层博客主题
 
 ### 插件
 


### PR DESCRIPTION
#### 仓库地址

https://github.com/sky121666/theme-sky-blog-3

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
Sky Blog 3 — macOS 桌面风格 Halo 博客主题。

核心特性：
- macOS 风格桌面：可拖拽图标、Dock 栏（放大动画）、顶部菜单栏、多窗口管理
- 桌面小组件：天气、站点统计、作者卡片、瞬间社交动态卡片，布局可拖拽编辑并持久化到后台
- 瞬间 (Moments) 窗口：微信 PC 朋友圈风格信息流，Light/Dark 双主题，封面自定义上传
- Pjax 全站无刷新导航，图片懒加载，评论延迟初始化
- Finder 风格归档 / 标签 / 分类 / 作者页
- macOS 系统弹窗风格错误页
- 7 组后台设置：顶栏、桌面、小组件、Dock、瞬间、默认布局、开发者

环境要求：Halo ≥ 2.23.0
推荐插件：plugin-moments、plugin-comment-widget、plugin-search-widget
```
