### PR TITLE
Halo plugin navidrome player

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 #### 应用市场
 
-- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。
+- [ ] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。
 
 <!--
 当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 #### 应用市场
 
-- [ ] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。
+- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。
 
 <!--
 当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@
 - [plugin-shiki](https://github.com/halo-sigs/plugin-shiki) - 适用于 Halo 的 Shiki 代码高亮插件，为文章等内容的代码块提供高亮渲染支持。
 
 #### 社区
-
+- [halo-plugin-navidrome-player](https://github.com/queenyn/halo-plugin-navidrome-player) - 一款为 Halo 博客集成 Navidrome（Subsonic API）前台音乐播放器的插件，支持歌单播放、悬浮控制与多歌单切换。
 - [plugin-prismjs](https://github.com/liuzhihang/plugin-prismjs) - Halo 2.0 的代码高亮 [Prism.js](https://github.com/PrismJS/prism) 插件
 - [plugin-colorless](https://github.com/guqing/halo-plugin-colorless) - 支持让 Halo 所有主题都失去色彩，展示为灰白效果，支持设置结束日期和作用范围。
 - [plugin-pixabay](https://github.com/microhalo/plugin-pixabay) - Halo 2.0 的 Pixabay 插件，支持从 Pixabay 选择图片


### PR DESCRIPTION
#### 仓库地址

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
None
```
