### PR TITLE
添加：数学公式渲染插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@
 - [plugin-online](https://github.com/Zyx-2012/plugin-online) - 让用户看到有多少人在与他看同一个页面。
 - [halo-plugin-transformer](https://github.com/HowieHz/halo-plugin-transformer) - 适用于 Halo 的页面转换器插件，按规则改写指定页面内容。
 - [halo-plugin-dishes](https://github.com/Avrinbai/halo-plugin-dishes) -  一个家庭点菜插件，支持菜品管理、分类管理、点餐记录等功能，适用于家庭或小型场景。
+- [plugin-kmath](https://github.com/Akvicor/plugin-kmath) - 为默认编辑器和文章渲染提供 KaTeX/MathJax 支持
 
 ### 其他
 


### PR DESCRIPTION
#### 仓库地址

[https://github.com/Akvicor/plugin-kmath](https://github.com/Akvicor/plugin-kmath)

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

## Halo 官网用户名

akvicor

```release-note
数学公式渲染插件，兼容官方插件，支持选择katex的输出格式，并额外增加对mathjax的支持。
```
