### PR TITLE
Add halo-private-posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@
 - [plugin-shiki](https://github.com/halo-sigs/plugin-shiki) - 适用于 Halo 的 Shiki 代码高亮插件，为文章等内容的代码块提供高亮渲染支持。
 
 #### 社区
-- [halo-private-posts](https://github.com/BairongLuo/halo-private-posts) - 为 Halo 提供加密正文、浏览器本地解密和自动重锁的私密文章插件。
 - [halo-plugin-navidrome-player](https://github.com/queenyn/halo-plugin-navidrome-player) - 一款为 Halo 博客集成 Navidrome（Subsonic API）前台音乐播放器的插件，支持歌单播放、悬浮控制与多歌单切换。
 - [plugin-prismjs](https://github.com/liuzhihang/plugin-prismjs) - Halo 2.0 的代码高亮 [Prism.js](https://github.com/PrismJS/prism) 插件
 - [plugin-colorless](https://github.com/guqing/halo-plugin-colorless) - 支持让 Halo 所有主题都失去色彩，展示为灰白效果，支持设置结束日期和作用范围。
@@ -205,6 +204,7 @@
 - [plugin-online](https://github.com/Zyx-2012/plugin-online) - 让用户看到有多少人在与他看同一个页面。
 - [halo-plugin-transformer](https://github.com/HowieHz/halo-plugin-transformer) - 适用于 Halo 的页面转换器插件，按规则改写指定页面内容。
 - [halo-plugin-dishes](https://github.com/Avrinbai/halo-plugin-dishes) -  一个家庭点菜插件，支持菜品管理、分类管理、点餐记录等功能，适用于家庭或小型场景。
+- [halo-private-posts](https://github.com/BairongLuo/halo-private-posts) - 为 Halo 提供加密正文、浏览器本地解密和自动重锁的私密文章插件。
 
 ### 其他
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@
 - [plugin-shiki](https://github.com/halo-sigs/plugin-shiki) - 适用于 Halo 的 Shiki 代码高亮插件，为文章等内容的代码块提供高亮渲染支持。
 
 #### 社区
+- [halo-private-posts](https://github.com/BairongLuo/halo-private-posts) - 为 Halo 提供加密正文、浏览器本地解密和自动重锁的私密文章插件。
 - [halo-plugin-navidrome-player](https://github.com/queenyn/halo-plugin-navidrome-player) - 一款为 Halo 博客集成 Navidrome（Subsonic API）前台音乐播放器的插件，支持歌单播放、悬浮控制与多歌单切换。
 - [plugin-prismjs](https://github.com/liuzhihang/plugin-prismjs) - Halo 2.0 的代码高亮 [Prism.js](https://github.com/PrismJS/prism) 插件
 - [plugin-colorless](https://github.com/guqing/halo-plugin-colorless) - 支持让 Halo 所有主题都失去色彩，展示为灰白效果，支持设置结束日期和作用范围。


### PR DESCRIPTION
#### 仓库地址

https://github.com/BairongLuo/halo-private-posts

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

#### 补充说明

- 当前版本：v1.0.1
- Release：https://github.com/BairongLuo/halo-private-posts/releases/tag/v1.0.1
- 支持联系：https://github.com/BairongLuo/halo-private-posts/issues
- 兼容 Halo：>=2.24.0

```release-note
新增社区插件 halo-private-posts，提供文章正文加密、浏览器本地解密和自动重锁能力。
```