### PR TITLE
Add halo-theme-halorum

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [Wing](https://github.com/waistu/halo-theme-Wing) - 一款简洁流畅、数据驱动的响应式主题。
 - [theme-sky-blog-3(macos)](https://github.com/sky121666/theme-sky-blog-3) - Apple-like macOS 桌面壳层博客主题
 - [halo-theme-gui](https://github.com/CirillaQL/halo-theme-gui) - 传统水墨风格的 Halo 博客主题，以宣纸底色、书法题字与朱红点缀营造疏朗安静的主题。
+- [halo-theme-halorum](https://github.com/xzyone/halo-theme-halorum) - Halorum 是一款面向 Halo 的轻论坛风格主题，基于 [mulingyuer/Typecho_Theme_JJ](https://github.com/mulingyuer/Typecho_Theme_JJ) 的视觉语言移植并重构。
 
 
 ### 插件


### PR DESCRIPTION
#### 仓库地址

https://github.com/xzyone/halo-theme-halorum

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
Halorum v0.0.1
初始发布版本。

主要内容
完成 Typecho_Theme_JJ 视觉风格到 Halo 主题的移植与重构。
使用 Astro 构建 Halo 模板产物。
支持论坛式首页、分页 / 无限加载、右侧信息栏和主题设置。
适配文章页、评论区、用户中心入口和通知入口。
```

Halo 官网用户名 xzy