### PR TITLE
添加：自定义微信分享卡片插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@
 - [halo-private-posts](https://github.com/BairongLuo/halo-private-posts) - 为 Halo 提供加密正文、浏览器本地解密和自动重锁的私密文章插件。
 - [plugin-kmath](https://github.com/Akvicor/plugin-kmath) - 为默认编辑器和文章渲染提供 KaTeX/MathJax 支持
 - [plugin-hitokoto-hub](https://github.com/PureSkys/plugin-hitokoto-hub) -  为你的网站注入"一句话"的灵动与温度。支持创建、管理海量句子，按分类归档，并提供随机获取、关键词搜索、点赞互动等丰富的开放接口。
+- [halo-plugin-wechat-share](https://github.com/Avrinbai/halo-plugin-wechat-share) - 基于Halo自定义微信分享卡片的标题、描述、封面、、链接，优化微信内分享展示效果。
 
 ### 其他
 


### PR DESCRIPTION
## 插件信息

- **插件名称：** 自定义微信分享卡片-WechatShare
- **插件仓库：** https://github.com/Avrinbai/halo-plugin-wechat-share
- **插件简介：** 自定义微信分享卡片的标题、描述、封面图、链接。

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。


## Halo 官网用户名

avrinbai

```release-note
 自定义微信分享卡片插件，支持自定义微信分享卡片的标题、描述、封面图、链接，适用于博客文章或其他网址优雅的分享到微信群/朋友圈。
```
