### PR TITLE
Fix link for plugin-hitokoto-hub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@
 - [halo-plugin-dishes](https://github.com/Avrinbai/halo-plugin-dishes) -  一个家庭点菜插件，支持菜品管理、分类管理、点餐记录等功能，适用于家庭或小型场景。
 - [halo-private-posts](https://github.com/BairongLuo/halo-private-posts) - 为 Halo 提供加密正文、浏览器本地解密和自动重锁的私密文章插件。
 - [plugin-kmath](https://github.com/Akvicor/plugin-kmath) - 为默认编辑器和文章渲染提供 KaTeX/MathJax 支持
-- [plugin-hitokoto-hub](https://github.com/PureSkys/plugin-hitokoto-hub) -  为你的网站注入"一句话"的灵动与温度。支持创建、管理海量句子，按分类归档，并提供随机获取、关键词搜索、点赞互动等丰富的开放接口。
+- [plugin-hitokoto-hub](https://github.com/imorisun/plugin-hitokoto-hub) -  为你的网站注入"一句话"的灵动与温度。支持创建、管理海量句子，按分类归档，并提供随机获取、关键词搜索、点赞互动等丰富的开放接口。
 
 ### 其他
 


### PR DESCRIPTION
Updated the link for the plugin-hitokoto-hub to a new repository.

#### 仓库地址
https://github.com/imorisun/plugin-hitokoto-hub

#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
修改了GitHub账户名，需修改已上架仓应用库地址及用户
```
