### PR TITLE
添加业余无线电卡片管理插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@
 - [plugin-kmath](https://github.com/Akvicor/plugin-kmath) - 为默认编辑器和文章渲染提供 KaTeX/MathJax 支持
 - [plugin-hitokoto-hub](https://github.com/imorisun/plugin-hitokoto-hub) -  为你的网站注入"一句话"的灵动与温度。支持创建、管理海量句子，按分类归档，并提供随机获取、关键词搜索、点赞互动等丰富的开放接口。
 - [halo-plugin-wechat-share](https://github.com/Avrinbai/halo-plugin-wechat-share) - 基于Halo自定义微信分享卡片的标题、描述、封面、、链接，优化微信内分享展示效果。
+- [plugin-qsl-management](https://github.com/bi1kbu/qsl-management) - 业余无线电系列插件（1）：业余无线电QSL卡片管理系统，用于QSO记录、QSL收发卡、线上EYEBALL收发卡、线下EYEBALL收发卡等场景
 
 ### 其他
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
 - [plugin-kmath](https://github.com/Akvicor/plugin-kmath) - 为默认编辑器和文章渲染提供 KaTeX/MathJax 支持
 - [plugin-hitokoto-hub](https://github.com/imorisun/plugin-hitokoto-hub) -  为你的网站注入"一句话"的灵动与温度。支持创建、管理海量句子，按分类归档，并提供随机获取、关键词搜索、点赞互动等丰富的开放接口。
 - [halo-plugin-wechat-share](https://github.com/Avrinbai/halo-plugin-wechat-share) - 基于Halo自定义微信分享卡片的标题、描述、封面、、链接，优化微信内分享展示效果。
-- [plugin-qsl-management](https://github.com/bi1kbu/qsl-management) - 业余无线电系列插件（1）：业余无线电QSL卡片管理系统，用于QSO记录、QSL收发卡、线上EYEBALL收发卡、线下EYEBALL收发卡等场景
+- [qsl-management](https://github.com/bi1kbu/qsl-management) - 业余无线电系列插件(1)：业余无线电QSL卡片管理系统，用于QSO记录、QSL收发卡、线上EYEBALL收发卡、线下EYEBALL收发卡等场景
 
 ### 其他
 


### PR DESCRIPTION
#### 仓库地址
[https://github.com/bi1kbu/qsl-management](https://github.com/bi1kbu/qsl-management)
#### 应用市场

- [x] 上架到 [Halo 应用市场](https://www.halo.run/store/apps)。

官网用户名：bi1kbu

<!--
当前 Halo 应用市场暂不支持开发者注册和发布应用，所以如果你需要上架到 Halo 应用市场，请勾选这个选项，我们会帮你上架。
如果你需要自行管理应用，可以在 PR 中提供 Halo 官网的用户名，我们会将应用的管理权限转移给你。
-->

```release-note
None
```
