### PR TITLE
新增插件 业余无线电通联记录网格地图

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@
 - [plugin-kmath](https://github.com/Akvicor/plugin-kmath) - 为默认编辑器和文章渲染提供 KaTeX/MathJax 支持
 - [plugin-hitokoto-hub](https://github.com/imorisun/plugin-hitokoto-hub) -  为你的网站注入"一句话"的灵动与温度。支持创建、管理海量句子，按分类归档，并提供随机获取、关键词搜索、点赞互动等丰富的开放接口。
 - [halo-plugin-wechat-share](https://github.com/Avrinbai/halo-plugin-wechat-share) - 基于Halo自定义微信分享卡片的标题、描述、封面、、链接，优化微信内分享展示效果。
+- [plugin-qsl-management](https://github.com/bi1kbu/qsl-management) - 业余无线电系列插件（1）：业余无线电QSL卡片管理系统，用于QSO记录、QSL收发卡、线上EYEBALL收发卡、线下EYEBALL收发卡等场景
 
 ### 其他
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@
 - [qsl-management](https://github.com/bi1kbu/qsl-management) - 业余无线电系列插件(1)：业余无线电QSL卡片管理系统，用于QSO记录、QSL收发卡、线上EYEBALL收发卡、线下EYEBALL收发卡等场景
 - [halo-weread-plugin](https://github.com/uuaki/halo-weread-plugin) - 为 Halo 提供 微信读书记录展示
 - [halo-plugin-bark](https://github.com/pig-gua/halo-plugin-bark) - 为 Halo 提供 bark 推送功能，支持将事件消息实时推送到IOS设备。
+- [qsl-grid-map](https://github.com/bi1kbu/qsl-grid-map) - 业余无线电系列插件(2)：业余无线电通联记录网格地图，基于 qsl-management 插件的公开网格接口，用于展示 QSO 通联网格覆盖情况、在前台页面直观查看当前电台已通联地区分布。
 
 ### 其他
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
 - [plugin-kmath](https://github.com/Akvicor/plugin-kmath) - 为默认编辑器和文章渲染提供 KaTeX/MathJax 支持
 - [plugin-hitokoto-hub](https://github.com/imorisun/plugin-hitokoto-hub) -  为你的网站注入"一句话"的灵动与温度。支持创建、管理海量句子，按分类归档，并提供随机获取、关键词搜索、点赞互动等丰富的开放接口。
 - [halo-plugin-wechat-share](https://github.com/Avrinbai/halo-plugin-wechat-share) - 基于Halo自定义微信分享卡片的标题、描述、封面、、链接，优化微信内分享展示效果。
-- [plugin-qsl-management](https://github.com/bi1kbu/qsl-management) - 业余无线电系列插件（1）：业余无线电QSL卡片管理系统，用于QSO记录、QSL收发卡、线上EYEBALL收发卡、线下EYEBALL收发卡等场景
+- [qsl-management](https://github.com/bi1kbu/qsl-management) - 业余无线电系列插件(1)：业余无线电QSL卡片管理系统，用于QSO记录、QSL收发卡、线上EYEBALL收发卡、线下EYEBALL收发卡等场景
 
 ### 其他
 


### PR DESCRIPTION
#### 仓库地址

https://github.com/[bi1kbu/qsl-grid-map](https://github.com/bi1kbu/qsl-grid-map)

<!--
如果需要上架到 Halo 应用市场，可以参考：https://docs.halo.run/developer-guide/app-store/publish-app
-->

上架到应用市场（非第一次上架）